### PR TITLE
`esc` returns to mailbox when viewing thread

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -122,6 +122,11 @@ function handleListDelete (event) {
   }
 }
 
+function handleThreadShortcut (combo) {
+  const filter = () => $('#mail .v-Thread')
+  return handleShortcut(combo, filter)
+}
+
 // ---------------------------------------------------------------------------------------------------------------------
 // selection
 // ---------------------------------------------------------------------------------------------------------------------
@@ -296,6 +301,9 @@ const handlers = {
   AltArrowDown: handleShowFolder(1),
   AltArrowLeft: handleToggleFolder(-1),
   AltArrowRight: handleToggleFolder(1),
+
+  // thread view
+  Escape: handleThreadShortcut('U')
 }
 
 document.addEventListener('keydown', function (event) {


### PR DESCRIPTION
Great work with this extension! It probably kept me from cancelling my brand new Fastmail account 😄 I just can't seem to adapt to some of their keyboard shortcuts...

This change allows you to return to the message list (Inbox, All mail, a folder, etc) using the Escape key when viewing a conversation thread.

I don't know if you still use Fastmail or accept contributions 🤷🏻‍♂️ 